### PR TITLE
Use correct standard library math functions, add missing header includes

### DIFF
--- a/examples/qmake/convert_maps.cpp
+++ b/examples/qmake/convert_maps.cpp
@@ -43,7 +43,7 @@ int main( int, char*[] )
 
         static auto punc = []( const float t )
         {
-            if ( std::fmodf( t, 1.f ) != 0.f ) {
+            if ( std::fmod( t, 1.f ) != 0.f ) {
                 return "f";
             }
 

--- a/include/vivid/colormap.h
+++ b/include/vivid/colormap.h
@@ -17,6 +17,7 @@
 
 #include "vivid/types.h"
 #include <vector>
+#include <string>
 
 namespace vivid {
 

--- a/src/colormap.cpp
+++ b/src/colormap.cpp
@@ -10,6 +10,9 @@
 #include <fstream>
 #include <iostream>
 
+#include <cmath>
+#include <string>
+
 namespace vivid {
 
 
@@ -54,7 +57,7 @@ srgb_t ColorMap::at( const float t ) const
         return stops_.back();
     }
 
-    const auto u = std::fmodf( sf, 1.f );
+    const auto u = std::fmod( sf, 1.f );
 
     switch ( interpolation )
     {

--- a/src/colormap.cpp
+++ b/src/colormap.cpp
@@ -9,7 +9,6 @@
 #include <nlohmann/json.hpp>
 #include <fstream>
 #include <iostream>
-
 #include <cmath>
 #include <string>
 

--- a/src/hsl.cpp
+++ b/src/hsl.cpp
@@ -27,7 +27,7 @@ hsl_t fromRgb( const rgb_t& rgb )
     }
 
     if ( glm::epsilonEqual( cmax, rgb.x, glm::epsilon<float>() ) ) {
-        hsl.x = std::fmodf( ( rgb.y - rgb.z ) / delta, 6.f );
+        hsl.x = std::fmod( ( rgb.y - rgb.z ) / delta, 6.f );
     } else if ( glm::epsilonEqual( cmax, rgb.y, glm::epsilon<float>() ) ) {
         hsl.x = ( rgb.z - rgb.x ) / delta + 2.f;
     } else {
@@ -36,7 +36,7 @@ hsl_t fromRgb( const rgb_t& rgb )
 
     hsl.y = delta / ( 1.f - std::abs( 2.f * hsl.z - 1.f ) );
     hsl.x /= 6.f;
-    hsl.x = std::fmodf( hsl.x + 1.f, 1.f );
+    hsl.x = std::fmod( hsl.x + 1.f, 1.f );
 
     return hsl;
 }

--- a/src/hsv.cpp
+++ b/src/hsv.cpp
@@ -37,7 +37,7 @@ hsv_t fromRgb( const rgb_t& rgb )
     }
 
     hsv.x /= 6.f;
-    hsv.x = std::fmodf( hsv.x + 1.f, 1.f );
+    hsv.x = std::fmod( hsv.x + 1.f, 1.f );
 
     return hsv;
 }

--- a/src/interpolation.cpp
+++ b/src/interpolation.cpp
@@ -30,7 +30,7 @@ hsl_t lerp( const hsl_t& hsl1, const hsl_t& hsl2, const float t )
     }
 
     auto hsl = hsl1a + t * ( hsl2 - hsl1a );
-    hsl.x = std::fmodf( hsl.x + 1.f, 1.f );
+    hsl.x = std::fmod( hsl.x + 1.f, 1.f );
 
     return static_cast<hsl_t>( hsl );
 }
@@ -51,7 +51,7 @@ hsv_t lerp( const hsv_t& hsv1, const hsv_t& hsv2, const float t )
     }
 
     auto hsv = hsv1a + t * ( hsv2 - hsv1a );
-    hsv.x = std::fmodf( hsv.x + 1.f, 1.f );
+    hsv.x = std::fmod( hsv.x + 1.f, 1.f );
 
     return static_cast<hsv_t>( hsv );
 }
@@ -72,7 +72,7 @@ lch_t lerp( const lch_t& lch1, const lch_t& lch2, const float t )
     auto interp = lch1 + t * delta;
 
     //  project back to [0; 360]
-    interp.z = std::fmodf( interp.z + 360.f, 360.f );
+    interp.z = std::fmod( interp.z + 360.f, 360.f );
     return static_cast<lch_t>( interp );
 }
 

--- a/src/lab.cpp
+++ b/src/lab.cpp
@@ -38,8 +38,8 @@ lab_t fromLch( const lch_t& lch )
 {
     lab_t lab;
     lab.x = lch.x;
-    lab.y = lch.y * std::cosf( glm::radians( lch.z ) );
-    lab.z = lch.y * std::sinf( glm::radians( lch.z ) );
+    lab.y = lch.y * std::cos( glm::radians( lch.z ) );
+    lab.z = lch.y * std::sin( glm::radians( lch.z ) );
 
     return lab;
 }

--- a/src/lch.cpp
+++ b/src/lch.cpp
@@ -9,11 +9,11 @@ namespace vivid::lch {
 ////////////////////////////////////////////////////////////////////////////////
 lch_t fromLab( const lab_t& lab )
 {
-    const float h = glm::degrees( std::atan2f( lab.z, lab.y ) );
+    const float h = glm::degrees( std::atan2( lab.z, lab.y ) );
 
     lch_t lch;
     lch.x = lab.x;
-    lch.y = std::sqrtf( lab.y * lab.y + lab.z * lab.z );
+    lch.y = std::sqrt( lab.y * lab.y + lab.z * lab.z );
     lch.z = ( h >= 0 ) ? h : ( h + 360.f );
 
     return lch;

--- a/src/rgb.cpp
+++ b/src/rgb.cpp
@@ -8,7 +8,6 @@
 #include <glm/gtx/string_cast.hpp>
 
 #include <cmath>
-
 #include <iostream>
 
 namespace vivid::rgb {

--- a/src/rgb.cpp
+++ b/src/rgb.cpp
@@ -7,6 +7,8 @@
 #include <glm/gtc/constants.hpp>    //  pi
 #include <glm/gtx/string_cast.hpp>
 
+#include <cmath>
+
 #include <iostream>
 
 namespace vivid::rgb {
@@ -33,7 +35,7 @@ rgb_t fromRgb32( const uint32_t rgb32 ) {
 ////////////////////////////////////////////////////////////////////////////////
 rgb_t fromHsv( const hsv_t& hsv )
 {
-    float h = ( hsv.x > 0.f ) ? ( std::fmodf( hsv.x, 1.f ) ) : ( 1.f + std::fmodf( hsv.x, 1.f ) );   //  wrap
+    float h = ( hsv.x > 0.f ) ? ( std::fmod( hsv.x, 1.f ) ) : ( 1.f + std::fmod( hsv.x, 1.f ) );   //  wrap
     float s = glm::clamp( hsv.y, 0.f, 1.f );
     float v = glm::clamp( hsv.z, 0.f, 1.f );
 
@@ -44,9 +46,9 @@ rgb_t fromHsv( const hsv_t& hsv )
     rgb_t rgb = {};
 
     const float k = h * 6.f;
-    const int d = int( std::floorf( k ) );
+    const int d = int( std::floor( k ) );
     const float C = v * s;
-    const float X = C * ( 1.f - std::fabsf( std::fmodf( k, 2.f ) - 1.f ) );
+    const float X = C * ( 1.f - std::abs( std::fmod( k, 2.f ) - 1.f ) );
     const float m = v - C;
 
     switch( d )
@@ -69,9 +71,9 @@ rgb_t fromHsl( const hsl_t& hsl )
 {
     const float k = hsl.x * 6.f;
     const float C = ( 1.f - std::abs( 2.f * hsl.z - 1.f ) ) * hsl.y;
-    const float X = C * ( 1.f - std::abs( std::fmodf( k, 2.f ) - 1.f ) );
+    const float X = C * ( 1.f - std::abs( std::fmod( k, 2.f ) - 1.f ) );
     const float m = hsl.z - C / 2.f;
-    const int d = int( std::floorf( k ) );
+    const int d = int( std::floor( k ) );
 
     rgb_t rgb = {};
 

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <sstream>
 #include <cstdio>
+#include <cmath>
 
 namespace vivid {
 namespace rgb {
@@ -70,7 +71,7 @@ float inverseCompound( const float k )
         return k / 12.92f;
     }
 
-    return std::powf( ( k + 0.055f ) / 1.055f, 2.4f );
+    return std::pow( ( k + 0.055f ) / 1.055f, 2.4f );
 }
 
 

--- a/tests/utility.h
+++ b/tests/utility.h
@@ -9,7 +9,7 @@ inline float randf( const float from = 0.f, const float to = 1.f )
     static std::random_device rd;
     static std::mt19937 mt( rd() );
 
-    std::uniform_real_distribution dist( from, to );
+    std::uniform_real_distribution<> dist( from, to );
     return dist( mt );
 };
 
@@ -19,7 +19,7 @@ inline int randi( const int from = 0, const int to = 255 )
     static std::random_device rd;
     static std::mt19937 mt( rd() );
 
-    std::uniform_int_distribution dist( from, to );
+    std::uniform_int_distribution<> dist( from, to );
     return dist( mt );
 };
 


### PR DESCRIPTION
With these changes, the project successfully builds against GCC 6 (boost::optional is required as a substitute for older compilers/language versions, but this is a drop-in replacement and the project otherwise builds fine and tests pass).

The 'f' suffixed variants of the math functions are actually a C-ism and are not part of the std namespace.  Moreover, the std-namespace versions are better as they automatically choose the correct overload based on input type.