### PR TITLE
Build tests and example only for direct build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,5 +86,16 @@ install(
 #  examples and tests
 ################################################################################
 
-add_subdirectory( examples )
-add_subdirectory( tests )
+string( TOUPPER ${PROJECT_NAME} PROJECT_PREFIX )
+
+option( ${PROJECT_PREFIX}_BUILD_TESTS "Build tests" ${PROJECT_IS_TOP_LEVEL} )
+
+if( ${PROJECT_PREFIX}_BUILD_TESTS )
+    add_subdirectory( tests )
+endif()
+
+option( ${PROJECT_PREFIX}_BUILD_EXAMPLES "Build examples" ${PROJECT_IS_TOP_LEVEL} )
+
+if( ${PROJECT_PREFIX}_BUILD_EXAMPLES )
+    add_subdirectory( examples )
+endif()


### PR DESCRIPTION
If this project is used as a third party lib
insided another project there is no need for
building examples and tests as well.

These are deactivated by default if it is
not built on its own.